### PR TITLE
Add max_len option in Dataset to restrict the max length of a tensor inputting to a model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add max_len option in Dataset to restrict the max length of a tensor inputting to a model https://github.com/colorfulscoop/convmodel/pull/20
+
 ## [v0.3.0]
 
 ### Added

--- a/convmodel/data/conv_dataset.py
+++ b/convmodel/data/conv_dataset.py
@@ -4,10 +4,20 @@ from convmodel.data import BufferedShuffleDataset
 
 
 class ConversationDataset(torch.utils.data.IterableDataset):
-    def __init__(self, iterator, tokenizer: ConversationTokenizer):
+    def __init__(
+        self,
+        iterator,
+        tokenizer: ConversationTokenizer,
+        max_len: int=None
+    ):
+        """
+        Args:
+            max_len: max length of a tensor input to a model
+        """
         super().__init__()
         self._iterator = iterator
         self._tokenizer = tokenizer
+        self._max_len = max_len
 
     def __iter__(self):
         """
@@ -16,6 +26,11 @@ class ConversationDataset(torch.utils.data.IterableDataset):
         for example in self._iterator:
             model_input = self._tokenizer(example.conversation)
             model_input["labels"] = model_input["input_ids"]
+
+            if self._max_len is not None:
+                for key, val in model_input.items():
+                    model_input[key] = val[:self._max_len]
+
             yield model_input
 
     @classmethod

--- a/convmodel/model.py
+++ b/convmodel/model.py
@@ -152,6 +152,7 @@ class ConversationModel:
         train_dataloader = ConversationDataset(
             iterator=train_iterator,
             tokenizer=self._tokenizer,
+            max_len=model.config.n_positions,
         ).build_data_loader(
             shuffle_buffer_size=shuffle_buffer_size,
             batch_size=batch_size,
@@ -162,6 +163,7 @@ class ConversationModel:
         valid_dataloader = ConversationDataset(
             iterator=valid_iterator,
             tokenizer=self._tokenizer,
+            max_len=model.config.n_positions,
         ).build_data_loader(
             # Do NOT need to shuffle validation data
             shuffle_buffer_size=None,
@@ -269,6 +271,7 @@ class ConversationModel:
         eval_dataloader = ConversationDataset(
             iterator=eval_iterator,
             tokenizer=self._tokenizer,
+            max_len=model.config.n_positions,
         ).build_data_loader(
             shuffle_buffer_size=None,
             batch_size=batch_size,

--- a/tests/small/data/conv_dataset_test.py
+++ b/tests/small/data/conv_dataset_test.py
@@ -63,6 +63,35 @@ def test_iter():
     assert got == want
 
 
+def test_iter_max_len():
+    corpus = [
+        Ex(conversation=["こんにちは"]),
+        Ex(conversation=["こんにちは", "私は誰誰です"]),
+    ]
+    tokenizer = ConversationTokenizer(tokenizer=TokenizerMock())
+    dataset = ConversationDataset(
+        iterator=corpus,
+        tokenizer=tokenizer,
+        max_len=7,
+    )
+    got = list(iter(dataset))
+    want = [
+        {
+            'input_ids': [5, 10272, 15, 679, 9, 5],
+            'token_type_ids': [0, 0, 0, 0, 0, 1],
+            'attention_mask': [1, 1, 1, 1, 1, 1],
+            "labels": [5, 10272, 15, 679, 9, 5]
+        },
+        {
+            'input_ids': [5, 10272, 15, 679, 9, 5, 5598],
+            'token_type_ids': [0, 0, 0, 0, 0, 1, 1],
+            'attention_mask': [1, 1, 1, 1, 1, 1, 1],
+            "labels": [5, 10272, 15, 679, 9, 5, 5598]
+        },
+    ]
+    assert got == want
+
+
 def test_build_data_loader():
     corpus = [
         Ex(conversation=["こんにちは"]),


### PR DESCRIPTION
This PR fixes an issue that training is failed when the input length is over the limit of a model.

To avoid it, this PR adds max_len option in Dataset to restrict the max length of a tensor inputting to a model.